### PR TITLE
Require cligen < 2.0.0 to fix failed build due to breaking cligen change

### DIFF
--- a/adix.nimble
+++ b/adix.nimble
@@ -6,7 +6,7 @@ license     = "MIT/ISC"
 
 # Deps
 requires    "nim >= 1.2.0"
-requires    "cligen >= 1.6.0"
+requires    "cligen >= 1.6.0 & < 2.0.0"
 skipDirs    = @[ "tests" ]
 
 bin         = @[


### PR DESCRIPTION
Both fitl and adix builds are failing right now as cligen changed its API.