### PR TITLE
Add missing dependency on fitl.

### DIFF
--- a/adix.nimble
+++ b/adix.nimble
@@ -7,6 +7,7 @@ license     = "MIT/ISC"
 # Deps
 requires    "nim >= 1.2.0"
 requires    "cligen >= 1.6.0"
+requires    "fitl >= 0.3.1"
 skipDirs    = @[ "tests" ]
 
 bin         = @[


### PR DESCRIPTION
```bash
Building adix/util/cstats using c backend
adix/util/cstats.nim(2, 25) Error: cannot open file: fitl/qtl
```

https://github.com/c-blake/adix/blob/5dcd4e642b12cef3b198e524bf0be6545cc6baa4/util/cstats.nim#L2